### PR TITLE
[WIP] Implement store state cache in ~/.kubicorn for #310

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,13 +1,13 @@
 Ajit Kumar <kumaraji@google.com>
+Alex Tasioulis <tasioulis.alex@gmail.com>
 Arpit Mohan <me@arpitmohan.com>
 Bo Ingram <boingram6@gmail.com>
 Brad Pinter <brad.pinter@gmail.com>
 Carolyn Van Slyck <me@carolynvanslyck.com>
 Darron Froese <dfroese@salesforce.com>
-ellenkorbes <ellenkorbes@gmail.com>
 Ellen Körbes <ellenkorbes@gmail.com>
 Eric Hole <eric.hole@gmail.com>
-fabriziopandini <fabrizio.pandini@gmail.com>
+Gar Morley <garmorley@gmail.com>
 Igor Vuk <parcijala@gmail.com>
 Joe Beda <joe.github@bedafamily.com>
 Jonathan Frederickson <jonathan@terracrypt.net>
@@ -24,10 +24,8 @@ Mario Mazo <mario.mazo@affinitas.de>
 Mario Mazo <mario.mazo@ravencall.io>
 Marko Mudrinić <mudrinic.mare@gmail.com>
 Martin Etmajer <martin@etmajer.com>
-matyix <janos.matyas@gmail.com>
 Michael Hausenblas <michael.hausenblas@gmail.com>
 Michael Zamot <michael@zamot.io>
-name <email@email.com>
 Nyah Check <check.nyah@gmail.com>
 Paul Czarkowski <username.taken@gmail.com>
 Peter Smeets <p.e.smeets@gmail.com>
@@ -37,3 +35,7 @@ Robert Bailey <robertbailey@google.com>
 Steven Klassen <sklassen@gmail.com>
 Ted Wood <ted@xy0.org>
 William Stewart <zoidbergwill@gmail.com>
+ellenkorbes <ellenkorbes@gmail.com>
+fabriziopandini <fabrizio.pandini@gmail.com>
+matyix <janos.matyas@gmail.com>
+name <email@email.com>

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -188,6 +188,12 @@
   version = "v0.0.2"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/mitchellh/go-homedir"
+  packages = ["."]
+  revision = "b8bc1bf767474819792c23f32d8286a45736f1c6"
+
+[[projects]]
   name = "github.com/pkg/errors"
   packages = ["."]
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
@@ -292,6 +298,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "db0a043f0beb8cda90ececf5c1cc539a559fd4a951e1c9388d9102f17a330fb8"
+  inputs-digest = "b7ebc0a03723931a11a467ceed3b8b4c3f33bcf025138314d349ac60d0b359e9"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -95,6 +95,7 @@ func RunApply(options *ApplyOptions) error {
 		logger.Info("Selected [fs] state store")
 		stateStore = fs.NewFileSystemStore(&fs.FileSystemStoreOptions{
 			BasePath:    options.StateStorePath,
+			CachePath:   options.CachedStateStorePath,
 			ClusterName: name,
 		})
 	case "jsonfs":
@@ -157,6 +158,8 @@ func RunApply(options *ApplyOptions) error {
 	if err != nil {
 		return fmt.Errorf("Unable to reconcile cluster: %v", err)
 	}
+
+	logger.Info("Caching state store for cluster [%s] in [~/.kubicorn]", options.Name)
 
 	err = stateStore.Commit(newCluster)
 	if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -73,12 +73,13 @@ var RootCmd = &cobra.Command{
 }
 
 type Options struct {
-	StateStore     string
-	StateStorePath string
-	Name           string
-	CloudId        string
-	Set            string
-	AwsProfile     string
+	StateStore           string
+	StateStorePath       string
+	CachedStateStorePath string
+	Name                 string
+	CloudId              string
+	Set                  string
+	AwsProfile           string
 }
 
 func Execute() {

--- a/state/filenames.go
+++ b/state/filenames.go
@@ -15,6 +15,7 @@
 package state
 
 const (
-	ClusterJSONFile = "cluster.json"
-	ClusterYamlFile = "cluster.yaml"
+	ClusterJSONFile  = "cluster.json"
+	ClusterYamlFile  = "cluster.yaml"
+	ClusterCacheFile = "~/.kubicorn"
 )

--- a/state/interface.go
+++ b/state/interface.go
@@ -19,6 +19,7 @@ import "github.com/kris-nova/kubicorn/apis/cluster"
 type ClusterStorer interface {
 	Exists() bool
 	ReadStore() ([]byte, error)
+	ReadCachedStore() ([]byte, error)
 	BytesToCluster(bytes []byte) (*cluster.Cluster, error)
 	Commit(cluster *cluster.Cluster) error
 	Destroy() error

--- a/state/jsonfs/impl.go
+++ b/state/jsonfs/impl.go
@@ -31,6 +31,7 @@ import (
 
 type JSONFileSystemStoreOptions struct {
 	BasePath    string
+	CachePath   string
 	ClusterName string
 }
 
@@ -42,6 +43,7 @@ type JSONFileSystemStore struct {
 	options      *JSONFileSystemStoreOptions
 	ClusterName  string
 	BasePath     string
+	CachePath    string
 	AbsolutePath string
 }
 
@@ -50,6 +52,7 @@ func NewJSONFileSystemStore(o *JSONFileSystemStoreOptions) *JSONFileSystemStore 
 		options:      o,
 		ClusterName:  o.ClusterName,
 		BasePath:     o.BasePath,
+		CachePath:    o.CachePath,
 		AbsolutePath: filepath.Join(o.BasePath, o.ClusterName),
 	}
 }
@@ -90,6 +93,10 @@ func (fs *JSONFileSystemStore) Read(relativePath string) ([]byte, error) {
 
 func (fs *JSONFileSystemStore) ReadStore() ([]byte, error) {
 	return fs.Read(state.ClusterJSONFile)
+}
+
+func (fs *JSONFileSystemStore) ReadCachedStore() ([]byte, error) {
+	return fs.Read(state.ClusterCacheFile)
 }
 
 func (fs *JSONFileSystemStore) Commit(c *cluster.Cluster) error {

--- a/vendor/github.com/mitchellh/go-homedir/LICENSE
+++ b/vendor/github.com/mitchellh/go-homedir/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2013 Mitchell Hashimoto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/mitchellh/go-homedir/README.md
+++ b/vendor/github.com/mitchellh/go-homedir/README.md
@@ -1,0 +1,14 @@
+# go-homedir
+
+This is a Go library for detecting the user's home directory without
+the use of cgo, so the library can be used in cross-compilation environments.
+
+Usage is incredibly simple, just call `homedir.Dir()` to get the home directory
+for a user, and `homedir.Expand()` to expand the `~` in a path to the home
+directory.
+
+**Why not just use `os/user`?** The built-in `os/user` package requires
+cgo on Darwin systems. This means that any Go code that uses that package
+cannot cross compile. But 99% of the time the use for `os/user` is just to
+retrieve the home directory, which we can do for the current user without
+cgo. This library does that, enabling cross-compilation.

--- a/vendor/github.com/mitchellh/go-homedir/homedir.go
+++ b/vendor/github.com/mitchellh/go-homedir/homedir.go
@@ -1,0 +1,137 @@
+package homedir
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// DisableCache will disable caching of the home directory. Caching is enabled
+// by default.
+var DisableCache bool
+
+var homedirCache string
+var cacheLock sync.RWMutex
+
+// Dir returns the home directory for the executing user.
+//
+// This uses an OS-specific method for discovering the home directory.
+// An error is returned if a home directory cannot be detected.
+func Dir() (string, error) {
+	if !DisableCache {
+		cacheLock.RLock()
+		cached := homedirCache
+		cacheLock.RUnlock()
+		if cached != "" {
+			return cached, nil
+		}
+	}
+
+	cacheLock.Lock()
+	defer cacheLock.Unlock()
+
+	var result string
+	var err error
+	if runtime.GOOS == "windows" {
+		result, err = dirWindows()
+	} else {
+		// Unix-like system, so just assume Unix
+		result, err = dirUnix()
+	}
+
+	if err != nil {
+		return "", err
+	}
+	homedirCache = result
+	return result, nil
+}
+
+// Expand expands the path to include the home directory if the path
+// is prefixed with `~`. If it isn't prefixed with `~`, the path is
+// returned as-is.
+func Expand(path string) (string, error) {
+	if len(path) == 0 {
+		return path, nil
+	}
+
+	if path[0] != '~' {
+		return path, nil
+	}
+
+	if len(path) > 1 && path[1] != '/' && path[1] != '\\' {
+		return "", errors.New("cannot expand user-specific home dir")
+	}
+
+	dir, err := Dir()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(dir, path[1:]), nil
+}
+
+func dirUnix() (string, error) {
+	// First prefer the HOME environmental variable
+	if home := os.Getenv("HOME"); home != "" {
+		return home, nil
+	}
+
+	// If that fails, try getent
+	var stdout bytes.Buffer
+	cmd := exec.Command("getent", "passwd", strconv.Itoa(os.Getuid()))
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		// If the error is ErrNotFound, we ignore it. Otherwise, return it.
+		if err != exec.ErrNotFound {
+			return "", err
+		}
+	} else {
+		if passwd := strings.TrimSpace(stdout.String()); passwd != "" {
+			// username:password:uid:gid:gecos:home:shell
+			passwdParts := strings.SplitN(passwd, ":", 7)
+			if len(passwdParts) > 5 {
+				return passwdParts[5], nil
+			}
+		}
+	}
+
+	// If all else fails, try the shell
+	stdout.Reset()
+	cmd = exec.Command("sh", "-c", "cd && pwd")
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+
+	result := strings.TrimSpace(stdout.String())
+	if result == "" {
+		return "", errors.New("blank output when reading home directory")
+	}
+
+	return result, nil
+}
+
+func dirWindows() (string, error) {
+	// First prefer the HOME environmental variable
+	if home := os.Getenv("HOME"); home != "" {
+		return home, nil
+	}
+
+	drive := os.Getenv("HOMEDRIVE")
+	path := os.Getenv("HOMEPATH")
+	home := drive + path
+	if drive == "" || path == "" {
+		home = os.Getenv("USERPROFILE")
+	}
+	if home == "" {
+		return "", errors.New("HOMEDRIVE, HOMEPATH, and USERPROFILE are blank")
+	}
+
+	return home, nil
+}

--- a/vendor/github.com/mitchellh/go-homedir/homedir_test.go
+++ b/vendor/github.com/mitchellh/go-homedir/homedir_test.go
@@ -1,0 +1,112 @@
+package homedir
+
+import (
+	"os"
+	"os/user"
+	"path/filepath"
+	"testing"
+)
+
+func patchEnv(key, value string) func() {
+	bck := os.Getenv(key)
+	deferFunc := func() {
+		os.Setenv(key, bck)
+	}
+
+	os.Setenv(key, value)
+	return deferFunc
+}
+
+func BenchmarkDir(b *testing.B) {
+	// We do this for any "warmups"
+	for i := 0; i < 10; i++ {
+		Dir()
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		Dir()
+	}
+}
+
+func TestDir(t *testing.T) {
+	u, err := user.Current()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	dir, err := Dir()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if u.HomeDir != dir {
+		t.Fatalf("%#v != %#v", u.HomeDir, dir)
+	}
+}
+
+func TestExpand(t *testing.T) {
+	u, err := user.Current()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	cases := []struct {
+		Input  string
+		Output string
+		Err    bool
+	}{
+		{
+			"/foo",
+			"/foo",
+			false,
+		},
+
+		{
+			"~/foo",
+			filepath.Join(u.HomeDir, "foo"),
+			false,
+		},
+
+		{
+			"",
+			"",
+			false,
+		},
+
+		{
+			"~",
+			u.HomeDir,
+			false,
+		},
+
+		{
+			"~foo/foo",
+			"",
+			true,
+		},
+	}
+
+	for _, tc := range cases {
+		actual, err := Expand(tc.Input)
+		if (err != nil) != tc.Err {
+			t.Fatalf("Input: %#v\n\nErr: %s", tc.Input, err)
+		}
+
+		if actual != tc.Output {
+			t.Fatalf("Input: %#v\n\nOutput: %#v", tc.Input, actual)
+		}
+	}
+
+	DisableCache = true
+	defer func() { DisableCache = false }()
+	defer patchEnv("HOME", "/custom/path/")()
+	expected := filepath.Join("/", "custom", "path", "foo/bar")
+	actual, err := Expand("~/foo/bar")
+
+	if err != nil {
+		t.Errorf("No error is expected, got: %v", err)
+	} else if actual != expected {
+		t.Errorf("Expected: %v; actual: %v", expected, actual)
+	}
+}


### PR DESCRIPTION
First part is to just save the state in `~/.kubicorn`. I think this should work for what was wanted in that issue (#310). Haven't implemented for the json as am looking for feedback first.

* Not sure about importing go-homedir... should I use the expandPath function instead? If so, how do I "bring" it to `fs/impl.go`? Looks like `apply.go` gets it from `create.go` but I'm not sure how.
* Should I implement any further logic in terms of when/how the state is cached?

Going forward I'll work with the ReadCachedState function to get the functionality that was envisioned as `kubicorn apply !!` -- since as was pointed out `!!` would be expanded to whatever was previously run in the shell, I'll try to use `kubicorn apply last-known-state` or `kubicorn apply --last-known-state` instead. 