### PR TITLE
Allow nodes to be added by changing local state file (digitalocean)

### DIFF
--- a/cloud/digitalocean/droplet/model.go
+++ b/cloud/digitalocean/droplet/model.go
@@ -70,6 +70,7 @@ func (m *Model) Resources() map[int]cloud.Resource {
 				},
 				Tags:       []string{serverPool.Name},
 				ServerPool: serverPool,
+				FirewallID: firewall.Identifier,
 			}
 
 			for _, rule := range firewall.IngressRules {
@@ -118,6 +119,7 @@ func (m *Model) Resources() map[int]cloud.Resource {
 				}
 				f.OutboundRules = append(f.OutboundRules, OutboundRule)
 			}
+			f.Finish()
 			r[i] = f
 			i++
 		}

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -15,26 +15,23 @@
 package defaults
 
 import (
-	"github.com/kubicorn/kubicorn/apis/cluster"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+        "encoding/json"
+
+        "github.com/kubicorn/kubicorn/apis/cluster"
 )
 
 func NewClusterDefaults(base *cluster.Cluster) *cluster.Cluster {
-	new := &cluster.Cluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Annotations: base.ObjectMeta.Annotations,
-		},
-		Name:          base.Name,
-		CloudId:       base.CloudId,
-		Cloud:         base.Cloud,
-		Location:      base.Location,
-		Network:       base.Network,
-		SSH:           base.SSH,
-		Values:        base.Values,
-		KubernetesAPI: base.KubernetesAPI,
-		ServerPools:   base.ServerPools,
-		Project:       base.Project,
-		Components:    base.Components,
-	}
-	return new
+        // we need a deep clone, and also a copy of our pointer values
+        // because the result of this function will be used for writing.
+        // if we do not create copy's for the pointer values, we will
+        // write into the original values!
+
+        // this is ugly, because we ignore the errors, but otherwise
+        // i'd have to change the signature of this func.
+        // but i know that these structs are json serializable!
+        var newcluster cluster.Cluster
+        buf, _ := json.Marshal(base)
+        json.Unmarshal(buf, &newcluster)
+        return &newcluster
 }
+


### PR DESCRIPTION
hi,

this PR allows one to add nodes to a running cluster by simply increase the `maxCount` value in the state file and `apply` the same state again. `kubicorn` will create new nodes and add them to the cluster.

I'm not sure if this is a desired behaviour. If not, simply throw this PR away :-). But i like it to change the yaml-file and apply it again. It is comparable to the `kubectl apply ...`.

It is only implemented for the DO-model because that is my main cloud provider. I do not know what happens with the other providers. 