### PR TITLE
add the key to the agent only once so passphrase is only once needed

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -18,6 +18,7 @@ fabriziopandini <fabrizio.pandini@gmail.com>
 Gar Morley <garmorley@gmail.com>
 Igor Vuk <parcijala@gmail.com>
 Jacopo Nardiello <jacopo@sighup.io>
+Jason DeTiberus <detiber@gmail.com>
 Joe Beda <joe.github@bedafamily.com>
 Jonathan Frederickson <jonathan@terracrypt.net>
 Joshua Carp <jm.carp@gmail.com>
@@ -50,5 +51,6 @@ robjloranger <robjloranger@protonmail.com>
 S.Çağlar Onur <caglar@digitalocean.com>
 Steven Klassen <sklassen@gmail.com>
 Ted Wood <ted@xy0.org>
+Ulrich Schreiner <ulrich.schreiner@gmail.com>
 William Stewart <zoidbergwill@gmail.com>
 Xavier Lucas <xavier.lucas@corp.ovh.com>


### PR DESCRIPTION
When using a ssh-key with a passphrase the loop in `RetryGetConfig` always creates new agents and always add the key-file to the agent. This forces one to always enter the passphrase in every loop iteration. This PR fixes this by creating the ssh configuration once and using this configuration for the whole loop. So a passphrase must be entered only once.