### PR TITLE
[flags/cmd] place common flags into a set of functions that can be called to add them.

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -63,18 +63,12 @@ func ApplyCmd() *cobra.Command {
 
 	fs := applyCmd.Flags()
 
-	fs.StringVarP(&ao.StateStore, keyStateStore, "s", viper.GetString(keyStateStore), descStateStore)
-	fs.StringVarP(&ao.StateStorePath, keyStateStorePath, "S", viper.GetString(keyStateStorePath), descStateStorePath)
-	fs.StringVarP(&ao.Set, keyKubicornSet, "e", viper.GetString(keyKubicornSet), descSet)
+	bindCommonStateStoreFlags(ao.StateStoreOptions, fs)
+	bindCommonAwsFlags(ao.AwsOptions, fs)
 
+	fs.StringVarP(&ao.Set, keyKubicornSet, "e", viper.GetString(keyKubicornSet), descSet)
 	fs.StringVar(&ao.AwsProfile, keyAwsProfile, viper.GetString(keyAwsProfile), descAwsProfile)
 	fs.StringVar(&ao.GitRemote, keyGitConfig, viper.GetString(keyGitConfig), descGitConfig)
-	fs.StringVar(&ao.S3AccessKey, keyS3Access, viper.GetString(keyS3Access), descS3AccessKey)
-	fs.StringVar(&ao.S3SecretKey, keyS3Secret, viper.GetString(keyS3Secret), descS3SecretKey)
-	fs.StringVar(&ao.BucketEndpointURL, keyS3Endpoint, viper.GetString(keyS3Endpoint), descS3Endpoints)
-	fs.StringVar(&ao.BucketName, keyS3Bucket, viper.GetString(keyS3Bucket), descS3Bucket)
-
-	fs.BoolVar(&ao.BucketSSL, keyS3SSL, viper.GetBool(keyS3SSL), descS3SSL)
 
 	return applyCmd
 }

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -63,8 +63,8 @@ func ApplyCmd() *cobra.Command {
 
 	fs := applyCmd.Flags()
 
-	bindCommonStateStoreFlags(ao.StateStoreOptions, fs)
-	bindCommonAwsFlags(ao.AwsOptions, fs)
+	bindCommonStateStoreFlags(&ao.StateStoreOptions, fs)
+	bindCommonAwsFlags(&ao.AwsOptions, fs)
 
 	fs.StringVarP(&ao.Set, keyKubicornSet, "e", viper.GetString(keyKubicornSet), descSet)
 	fs.StringVar(&ao.AwsProfile, keyAwsProfile, viper.GetString(keyAwsProfile), descAwsProfile)

--- a/cmd/crd.go
+++ b/cmd/crd.go
@@ -56,16 +56,10 @@ All normal state store configuration is applicable for READING a state store, an
 
 	fs := crdCommand.Flags()
 
-	fs.StringVarP(&crdo.StateStore, keyStateStore, "s", viper.GetString(keyStateStore), descStateStore)
-	fs.StringVarP(&crdo.StateStorePath, keyStateStorePath, "S", viper.GetString(keyStateStorePath), descStateStorePath)
+	bindCommonStateStoreFlags(&crdo.StateStoreOptions, fs)
+	bindCommonAwsFlags(&crdo.AwsOptions, fs)
 
 	fs.StringVar(&crdo.GitRemote, keyGitConfig, viper.GetString(keyGitConfig), descGitConfig)
-	fs.StringVar(&crdo.S3AccessKey, keyS3Access, viper.GetString(keyS3Access), descS3AccessKey)
-	fs.StringVar(&crdo.S3SecretKey, keyS3Secret, viper.GetString(keyS3Secret), descS3SecretKey)
-	fs.StringVar(&crdo.BucketEndpointURL, keyS3Endpoint, viper.GetString(keyS3Endpoint), descS3Endpoints)
-	fs.StringVar(&crdo.BucketName, keyS3Bucket, viper.GetString(keyS3Bucket), descS3Bucket)
-
-	fs.BoolVar(&crdo.BucketSSL, keyS3SSL, viper.GetBool(keyS3SSL), descS3SSL)
 
 	return crdCommand
 }

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -63,8 +63,8 @@ func CreateCmd() *cobra.Command {
 
 	fs := createCmd.Flags()
 
-	bindCommonStateStoreFlags(co.StateStoreOptions, fs)
-	bindCommonAwsFlags(co.AwsOptions, fs)
+	bindCommonStateStoreFlags(&co.StateStoreOptions, fs)
+	bindCommonAwsFlags(&co.AwsOptions, fs)
 
 	fs.StringVarP(&co.Profile, keyProfile, "p", viper.GetString(keyProfile), descProfile)
 	fs.StringVarP(&co.CloudID, keyCloudID, "c", viper.GetString(keyCloudID), descCloudID)

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -63,19 +63,13 @@ func CreateCmd() *cobra.Command {
 
 	fs := createCmd.Flags()
 
-	fs.StringVarP(&co.StateStore, keyStateStore, "s", viper.GetString(keyStateStore), descStateStore)
-	fs.StringVarP(&co.StateStorePath, keyStateStorePath, "S", viper.GetString(keyStateStorePath), descStateStorePath)
+	bindCommonStateStoreFlags(co.StateStoreOptions, fs)
+	bindCommonAwsFlags(co.AwsOptions, fs)
+
 	fs.StringVarP(&co.Profile, keyProfile, "p", viper.GetString(keyProfile), descProfile)
 	fs.StringVarP(&co.CloudID, keyCloudID, "c", viper.GetString(keyCloudID), descCloudID)
 	fs.StringVarP(&co.Set, keySet, "e", viper.GetString(keySet), descSet)
 	fs.StringVarP(&co.GitRemote, keyGitConfig, "g", viper.GetString(keyGitConfig), descGitConfig)
-
-	fs.StringVar(&co.S3AccessKey, keyS3Access, viper.GetString(keyS3Access), descS3AccessKey)
-	fs.StringVar(&co.S3SecretKey, keyS3Secret, viper.GetString(keyS3Secret), descS3SecretKey)
-	fs.StringVar(&co.BucketEndpointURL, keyS3Endpoint, viper.GetString(keyS3Endpoint), descS3Endpoints)
-	fs.StringVar(&co.BucketName, keyS3Bucket, viper.GetString(keyS3Bucket), descS3Bucket)
-
-	fs.BoolVar(&co.BucketSSL, keyS3SSL, viper.GetBool(keyS3SSL), descS3SSL)
 
 	flagApplyAnnotations(createCmd, "profile", "__kubicorn_parse_profiles")
 	flagApplyAnnotations(createCmd, "cloudid", "__kubicorn_parse_cloudid")

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -62,8 +62,8 @@ func DeleteCmd() *cobra.Command {
 
 	fs := deleteCmd.Flags()
 
-	bindCommonStateStoreFlags(do.StateStoreOptions, fs)
-	bindCommonAwsFlags(do.AwsOptions, fs)
+	bindCommonStateStoreFlags(&do.StateStoreOptions, fs)
+	bindCommonAwsFlags(&do.AwsOptions, fs)
 
 	fs.StringVar(&do.AwsProfile, keyAwsProfile, viper.GetString(keyAwsProfile), descAwsProfile)
 	fs.StringVar(&do.GitRemote, keyGitConfig, viper.GetString(keyGitConfig), descGitConfig)

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -62,18 +62,11 @@ func DeleteCmd() *cobra.Command {
 
 	fs := deleteCmd.Flags()
 
-	fs.StringVarP(&do.StateStore, keyStateStore, "s", viper.GetString(keyStateStore), descStateStore)
-	fs.StringVarP(&do.StateStorePath, keyStateStorePath, "S", viper.GetString(keyStateStorePath), descStateStorePath)
+	bindCommonStateStoreFlags(do.StateStoreOptions, fs)
+	bindCommonAwsFlags(do.AwsOptions, fs)
 
 	fs.StringVar(&do.AwsProfile, keyAwsProfile, viper.GetString(keyAwsProfile), descAwsProfile)
 	fs.StringVar(&do.GitRemote, keyGitConfig, viper.GetString(keyGitConfig), descGitConfig)
-	fs.StringVar(&do.S3AccessKey, keyS3Access, viper.GetString(keyS3Access), descS3AccessKey)
-	fs.StringVar(&do.S3SecretKey, keyS3Secret, viper.GetString(keyS3Secret), descS3SecretKey)
-	fs.StringVar(&do.BucketEndpointURL, keyS3Endpoint, viper.GetString(keyS3Endpoint), descS3Endpoints)
-	fs.StringVar(&do.BucketName, keyS3Bucket, viper.GetString(keyS3Bucket), descS3Bucket)
-
-	fs.BoolVar(&do.BucketSSL, keyS3SSL, viper.GetBool(keyS3SSL), descS3SSL)
-
 	fs.BoolVarP(&do.Purge, keyPurge, "p", viper.GetBool(keyPurge), descPurge)
 
 	return deleteCmd

--- a/cmd/deploycontroller.go
+++ b/cmd/deploycontroller.go
@@ -57,16 +57,10 @@ As long as a controller is defined, this will create the deployment and the name
 
 	fs := deployControllerCmd.Flags()
 
-	fs.StringVarP(&dco.StateStore, keyStateStore, "s", viper.GetString(keyStateStore), descStateStore)
-	fs.StringVarP(&dco.StateStorePath, keyStateStorePath, "S", viper.GetString(keyStateStorePath), descStateStorePath)
+	bindCommonStateStoreFlags(&dco.StateStoreOptions, fs)
+	bindCommonAwsFlags(&dco.AwsOptions, fs)
 
 	fs.StringVar(&dco.GitRemote, keyGitConfig, viper.GetString(keyGitConfig), descGitConfig)
-	fs.StringVar(&dco.S3AccessKey, keyS3Access, viper.GetString(keyS3Access), descS3AccessKey)
-	fs.StringVar(&dco.S3SecretKey, keyS3Secret, viper.GetString(keyS3Secret), descS3SecretKey)
-	fs.StringVar(&dco.BucketEndpointURL, keyS3Endpoint, viper.GetString(keyS3Endpoint), descS3Endpoints)
-	fs.StringVar(&dco.BucketName, keyS3Bucket, viper.GetString(keyS3Bucket), descS3Bucket)
-
-	fs.BoolVar(&dco.BucketSSL, keyS3SSL, viper.GetBool(keyS3SSL), descS3SSL)
 
 	return deployControllerCmd
 }

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -55,17 +55,11 @@ func EditCmd() *cobra.Command {
 
 	fs := editCmd.Flags()
 
-	fs.StringVarP(&eo.StateStore, keyStateStore, "s", viper.GetString(keyStateStore), descStateStore)
-	fs.StringVarP(&eo.StateStorePath, keyStateStorePath, "S", viper.GetString(keyStateStorePath), descStateStorePath)
+	bindCommonStateStoreFlags(eo.StateStoreOptions, fs)
+	bindCommonAwsFlags(eo.AwsOptions, fs)
+
 	fs.StringVarP(&eo.Editor, keyEditor, "e", viper.GetString(keyEditor), descEditor)
-
 	fs.StringVar(&eo.GitRemote, keyGitConfig, viper.GetString(keyGitConfig), descGitConfig)
-	fs.StringVar(&eo.S3AccessKey, keyS3Access, viper.GetString(keyS3Access), descS3AccessKey)
-	fs.StringVar(&eo.S3SecretKey, keyS3Secret, viper.GetString(keyS3Secret), descS3SecretKey)
-	fs.StringVar(&eo.BucketEndpointURL, keyS3Endpoint, viper.GetString(keyS3Endpoint), descS3Endpoints)
-	fs.StringVar(&eo.BucketName, keyS3Bucket, viper.GetString(keyS3Bucket), descS3Bucket)
-
-	fs.BoolVar(&eo.BucketSSL, keyS3SSL, viper.GetBool(keyS3SSL), descS3SSL)
 
 	return editCmd
 }

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -55,8 +55,8 @@ func EditCmd() *cobra.Command {
 
 	fs := editCmd.Flags()
 
-	bindCommonStateStoreFlags(eo.StateStoreOptions, fs)
-	bindCommonAwsFlags(eo.AwsOptions, fs)
+	bindCommonStateStoreFlags(&eo.StateStoreOptions, fs)
+	bindCommonAwsFlags(&eo.AwsOptions, fs)
 
 	fs.StringVarP(&eo.Editor, keyEditor, "e", viper.GetString(keyEditor), descEditor)
 	fs.StringVar(&eo.GitRemote, keyGitConfig, viper.GetString(keyGitConfig), descGitConfig)

--- a/cmd/explain.go
+++ b/cmd/explain.go
@@ -63,17 +63,11 @@ func ExplainCmd() *cobra.Command {
 
 	fs := cmd.Flags()
 
-	fs.StringVarP(&exo.StateStore, keyStateStore, "s", viper.GetString(keyStateStore), descStateStore)
-	fs.StringVarP(&exo.StateStorePath, keyStateStorePath, "S", viper.GetString(keyStateStorePath), descStateStorePath)
+	bindCommonStateStoreFlags(exo.StateStoreOptions, fs)
+	bindCommonAwsFlags(exo.AwsOptions, fs)
+
 	fs.StringVarP(&exo.Output, keyOutput, "o", viper.GetString(keyOutput), descOutput)
-
 	fs.StringVar(&exo.GitRemote, keyGitConfig, viper.GetString(keyGitConfig), descGitConfig)
-	fs.StringVar(&exo.S3AccessKey, keyS3Access, viper.GetString(keyS3Access), descS3AccessKey)
-	fs.StringVar(&exo.S3SecretKey, keyS3Secret, viper.GetString(keyS3Secret), descS3SecretKey)
-	fs.StringVar(&exo.BucketEndpointURL, keyS3Endpoint, viper.GetString(keyS3Endpoint), descS3Endpoints)
-	fs.StringVar(&exo.BucketName, keyS3Bucket, viper.GetString(keyS3Bucket), descS3Bucket)
-
-	fs.BoolVar(&exo.BucketSSL, keyS3SSL, viper.GetBool(keyS3SSL), descS3SSL)
 
 	return cmd
 }

--- a/cmd/explain.go
+++ b/cmd/explain.go
@@ -63,8 +63,8 @@ func ExplainCmd() *cobra.Command {
 
 	fs := cmd.Flags()
 
-	bindCommonStateStoreFlags(exo.StateStoreOptions, fs)
-	bindCommonAwsFlags(exo.AwsOptions, fs)
+	bindCommonStateStoreFlags(&exo.StateStoreOptions, fs)
+	bindCommonAwsFlags(&exo.AwsOptions, fs)
 
 	fs.StringVarP(&exo.Output, keyOutput, "o", viper.GetString(keyOutput), descOutput)
 	fs.StringVar(&exo.GitRemote, keyGitConfig, viper.GetString(keyGitConfig), descGitConfig)

--- a/cmd/getconfig.go
+++ b/cmd/getconfig.go
@@ -57,8 +57,8 @@ func GetConfigCmd() *cobra.Command {
 
 	fs := getConfigCmd.Flags()
 
-	bindCommonStateStoreFlags(cro.StateStoreOptions, fs)
-	bindCommonAwsFlags(cro.AwsOptions, fs)
+	bindCommonStateStoreFlags(&cro.StateStoreOptions, fs)
+	bindCommonAwsFlags(&cro.AwsOptions, fs)
 
 	fs.StringVar(&cro.GitRemote, keyGitConfig, viper.GetString(keyGitConfig), descGitConfig)
 

--- a/cmd/getconfig.go
+++ b/cmd/getconfig.go
@@ -57,16 +57,10 @@ func GetConfigCmd() *cobra.Command {
 
 	fs := getConfigCmd.Flags()
 
-	fs.StringVarP(&cro.StateStore, keyStateStore, "s", viper.GetString(keyStateStore), descStateStore)
-	fs.StringVarP(&cro.StateStorePath, keyStateStorePath, "S", viper.GetString(keyStateStorePath), descStateStorePath)
+	bindCommonStateStoreFlags(cro.StateStoreOptions, fs)
+	bindCommonAwsFlags(cro.AwsOptions, fs)
 
 	fs.StringVar(&cro.GitRemote, keyGitConfig, viper.GetString(keyGitConfig), descGitConfig)
-	fs.StringVar(&cro.S3AccessKey, keyS3Access, viper.GetString(keyS3Access), descS3AccessKey)
-	fs.StringVar(&cro.S3SecretKey, keyS3Secret, viper.GetString(keyS3Secret), descS3SecretKey)
-	fs.StringVar(&cro.BucketEndpointURL, keyS3Endpoint, viper.GetString(keyS3Endpoint), descS3Endpoints)
-	fs.StringVar(&cro.BucketName, keyS3Bucket, viper.GetString(keyS3Bucket), descS3Bucket)
-
-	fs.BoolVar(&cro.BucketSSL, keyS3SSL, viper.GetBool(keyS3SSL), descS3SSL)
 
 	return getConfigCmd
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -49,8 +49,8 @@ func ListCmd() *cobra.Command {
 
 	fs := cmd.Flags()
 
-	bindCommonStateStoreFlags(lo.StateStoreOptions, fs)
-	bindCommonAwsFlags(lo.AwsOptions, fs)
+	bindCommonStateStoreFlags(&lo.StateStoreOptions, fs)
+	bindCommonAwsFlags(&lo.AwsOptions, fs)
 
 	fs.BoolVarP(&noHeaders, keyNoHeaders, "n", viper.GetBool(keyNoHeaders), desNoHeaders)
 

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -49,17 +49,10 @@ func ListCmd() *cobra.Command {
 
 	fs := cmd.Flags()
 
-	fs.StringVarP(&lo.StateStore, keyStateStore, "s", viper.GetString(keyStateStore), descStateStore)
-	fs.StringVarP(&lo.StateStorePath, keyStateStorePath, "S", viper.GetString(keyStateStorePath), descStateStorePath)
-
-	fs.StringVar(&lo.S3AccessKey, keyS3Access, viper.GetString(keyS3Access), descS3AccessKey)
-	fs.StringVar(&lo.S3SecretKey, keyS3Secret, viper.GetString(keyS3Secret), descS3SecretKey)
-	fs.StringVar(&lo.BucketEndpointURL, keyS3Endpoint, viper.GetString(keyS3Endpoint), descS3Endpoints)
-	fs.StringVar(&lo.BucketName, keyS3Bucket, viper.GetString(keyS3Bucket), descS3Bucket)
+	bindCommonStateStoreFlags(lo.StateStoreOptions, fs)
+	bindCommonAwsFlags(lo.AwsOptions, fs)
 
 	fs.BoolVarP(&noHeaders, keyNoHeaders, "n", viper.GetBool(keyNoHeaders), desNoHeaders)
-
-	fs.BoolVar(&lo.BucketSSL, keyS3SSL, viper.GetBool(keyS3SSL), descS3SSL)
 
 	return cmd
 }

--- a/cmd/root_environment.go
+++ b/cmd/root_environment.go
@@ -130,7 +130,7 @@ func bindEnvVars() {
 	viper.BindEnv(keyS3Bucket, envVarS3Bucket)
 }
 
-func bindCommonAwsFlags(o cli.AwsOptions, fs *flag.FlagSet) {
+func bindCommonAwsFlags(o *cli.AwsOptions, fs *flag.FlagSet) {
 	fs.StringVar(&o.S3AccessKey, keyS3Access, viper.GetString(keyS3Access), descS3AccessKey)
 	fs.StringVar(&o.S3SecretKey, keyS3Secret, viper.GetString(keyS3Secret), descS3SecretKey)
 	fs.StringVar(&o.BucketEndpointURL, keyS3Endpoint, viper.GetString(keyS3Endpoint), descS3Endpoints)
@@ -139,7 +139,7 @@ func bindCommonAwsFlags(o cli.AwsOptions, fs *flag.FlagSet) {
 	fs.BoolVar(&o.BucketSSL, keyS3SSL, viper.GetBool(keyS3SSL), descS3SSL)
 }
 
-func bindCommonStateStoreFlags(o cli.StateStoreOptions, fs *flag.FlagSet) {
+func bindCommonStateStoreFlags(o *cli.StateStoreOptions, fs *flag.FlagSet) {
 	fs.StringVarP(&o.StateStore, keyStateStore, "s", viper.GetString(keyStateStore), descStateStore)
 	fs.StringVarP(&o.StateStorePath, keyStateStorePath, "S", viper.GetString(keyStateStorePath), descStateStorePath)
 }

--- a/cmd/root_environment.go
+++ b/cmd/root_environment.go
@@ -15,6 +15,8 @@
 package cmd
 
 import (
+	"github.com/kubicorn/kubicorn/pkg/cli"
+	flag "github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
 
@@ -126,4 +128,18 @@ func bindEnvVars() {
 	viper.BindEnv(keyS3Endpoint, enVarS3Endpoint)
 	viper.BindEnv(keyS3SSL, envVarS3SSL)
 	viper.BindEnv(keyS3Bucket, envVarS3Bucket)
+}
+
+func bindCommonAwsFlags(o cli.AwsOptions, fs *flag.FlagSet) {
+	fs.StringVar(&o.S3AccessKey, keyS3Access, viper.GetString(keyS3Access), descS3AccessKey)
+	fs.StringVar(&o.S3SecretKey, keyS3Secret, viper.GetString(keyS3Secret), descS3SecretKey)
+	fs.StringVar(&o.BucketEndpointURL, keyS3Endpoint, viper.GetString(keyS3Endpoint), descS3Endpoints)
+	fs.StringVar(&o.BucketName, keyS3Bucket, viper.GetString(keyS3Bucket), descS3Bucket)
+
+	fs.BoolVar(&o.BucketSSL, keyS3SSL, viper.GetBool(keyS3SSL), descS3SSL)
+}
+
+func bindCommonStateStoreFlags(o cli.StateStoreOptions, fs *flag.FlagSet) {
+	fs.StringVarP(&o.StateStore, keyStateStore, "s", viper.GetString(keyStateStore), descStateStore)
+	fs.StringVarP(&o.StateStorePath, keyStateStorePath, "S", viper.GetString(keyStateStorePath), descStateStorePath)
 }

--- a/pkg/cli/options.go
+++ b/pkg/cli/options.go
@@ -50,7 +50,6 @@ type DeployControllerOptions struct {
 	Options
 }
 
-
 // EditOptions represents edit command options.
 type EditOptions struct {
 	Options

--- a/pkg/cli/options.go
+++ b/pkg/cli/options.go
@@ -16,14 +16,23 @@ package cli
 
 // Options represents command options.
 type Options struct {
+	StateStoreOptions
+	Name       string
+	CloudID    string
+	Set        string
+	AwsProfile string
+	GitRemote  string
+	AwsOptions
+}
+
+//StateStoreOptions
+type StateStoreOptions struct {
 	StateStore     string
 	StateStorePath string
-	Name           string
-	CloudID        string
-	Set            string
-	AwsProfile     string
-	GitRemote      string
+}
 
+// AWS Options
+type AwsOptions struct {
 	S3AccessKey       string
 	S3SecretKey       string
 	BucketEndpointURL string
@@ -40,6 +49,7 @@ type CRDOptions struct {
 type DeployControllerOptions struct {
 	Options
 }
+
 
 // EditOptions represents edit command options.
 type EditOptions struct {


### PR DESCRIPTION
without breaking pkg api contracts, allow for common flags to be pulled into function calls that add to a command those flags. Should remove a lot of duplication of code.