### PR TITLE
cloud,bootstrap,google: fix cluster creation and provisioning

### DIFF
--- a/bootstrap/google_compute_k8s_ubuntu_16.04_node.sh
+++ b/bootstrap/google_compute_k8s_ubuntu_16.04_node.sh
@@ -4,25 +4,42 @@
 # and the shell script real work. If you need conditional logic, write it in bash or make another shell script.
 # ------------------------------------------------------------------------------------------------------------------------
 
-sudo curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
-sudo touch /etc/apt/sources.list.d/kubernetes.list
-sudo sh -c 'echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list'
+# Specify the Kubernetes version to use.
+KUBERNETES_VERSION="1.9.2"
+KUBERNETES_CNI="0.6.0"
 
-sudo apt-get update -y
-sudo apt-get install -y \
+# Obtain metadata.
+PRIVATEIP=`curl --retry 5 -sfH "Metadata-Flavor: Google" "http://metadata/computeMetadata/v1/instance/network-interfaces/0/ip"`
+PUBLICIP=`curl --retry 5 -sfH "Metadata-Flavor: Google" "http://metadata/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip"`
+HOSTNAME=`curl --retry 5 -sfH "Metadata-Flavor: Google" "http://metadata/computeMetadata/v1/instance/name"`
+echo $PRIVATEIP > /tmp/.ip
+
+# Add APT repository and GPG key.
+curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+touch /etc/apt/sources.list.d/kubernetes.list
+sh -c 'echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list'
+
+# Install packages.
+apt-get update -y
+apt-get install -y \
     socat \
     ebtables \
     docker.io \
     apt-transport-https \
-    kubelet \
-    kubeadm=1.7.0-00 \
+    kubelet=${KUBERNETES_VERSION}-00 \
+    kubeadm=${KUBERNETES_VERSION}-00 \
+    kubernetes-cni=${KUBERNETES_CNI}-00 \
+    cloud-utils \
     jq
 
-sudo systemctl enable docker
-sudo systemctl start docker
+# Enable and start Docker.
+systemctl enable docker
+systemctl start docker
 
+# Parse kubicorn configuration file.
 TOKEN=$(cat /etc/kubicorn/cluster.json | jq -r '.clusterAPI.spec.providerConfig' | jq -r '.values.itemMap.INJECTEDTOKEN')
 MASTER=$(cat /etc/kubicorn/cluster.json | jq -r '.clusterAPI.spec.providerConfig' | jq -r '.values.itemMap.INJECTEDMASTER')
 
-sudo -E kubeadm reset
-sudo -E kubeadm join --token ${TOKEN} ${MASTER}
+# Join node a cluster.
+kubeadm reset
+kubeadm join --node-name ${HOSTNAME} --token ${TOKEN} ${MASTER} --discovery-token-unsafe-skip-ca-verification

--- a/cloud/google/compute/resources/instancegroup.go
+++ b/cloud/google/compute/resources/instancegroup.go
@@ -181,7 +181,9 @@ func (r *InstanceGroup) Apply(actual, expected cloud.Resource, immutable *cluste
 			}
 
 			found = true
-			immutable.ProviderConfig().Values.ItemMap["INJECTEDMASTER"] = fmt.Sprintf("%s:%s", masterIPPrivate, immutable.ProviderConfig().KubernetesAPI.Port)
+			providerConfig := immutable.ProviderConfig()
+			providerConfig.Values.ItemMap["INJECTEDMASTER"] = fmt.Sprintf("%s:%s", masterIPPrivate, immutable.ProviderConfig().KubernetesAPI.Port)
+			immutable.SetProviderConfig(providerConfig)
 			break
 		}
 		if !found {
@@ -189,7 +191,9 @@ func (r *InstanceGroup) Apply(actual, expected cloud.Resource, immutable *cluste
 		}
 	}
 
-	immutable.ProviderConfig().Values.ItemMap["INJECTEDPORT"] = immutable.ProviderConfig().KubernetesAPI.Port
+	providerConfig := immutable.ProviderConfig()
+	providerConfig.Values.ItemMap["INJECTEDPORT"] = immutable.ProviderConfig().KubernetesAPI.Port
+	immutable.SetProviderConfig(providerConfig)
 
 	scripts, err := script.BuildBootstrapScript(r.ServerPool.BootstrapScripts, immutable)
 	if err != nil {
@@ -318,7 +322,10 @@ func (r *InstanceGroup) Apply(actual, expected cloud.Resource, immutable *cluste
 		Count:            expected.(*InstanceGroup).Count,
 		BootstrapScripts: expected.(*InstanceGroup).BootstrapScripts,
 	}
-	immutable.ProviderConfig().KubernetesAPI.Endpoint = masterIPPublic
+
+	providerConfig = immutable.ProviderConfig()
+	providerConfig.KubernetesAPI.Endpoint = masterIPPublic
+	immutable.SetProviderConfig(providerConfig)
 
 	renderedCluster, err := r.immutableRender(newResource, immutable)
 	if err != nil {
@@ -353,7 +360,9 @@ func (r *InstanceGroup) Delete(actual cloud.Resource, immutable *cluster.Cluster
 	}
 
 	// Kubernetes API
-	immutable.ProviderConfig().KubernetesAPI.Endpoint = ""
+	providerConfig := immutable.ProviderConfig()
+	providerConfig.KubernetesAPI.Endpoint = ""
+	immutable.SetProviderConfig(providerConfig)
 	renderedCluster, err := r.immutableRender(actual, immutable)
 	if err != nil {
 		return nil, nil, err

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -115,7 +115,10 @@ func RunCreate(options *cli.CreateOptions) error {
 	if newCluster.ProviderConfig().Cloud == cluster.CloudGoogle && options.CloudID == "" {
 		return fmt.Errorf("CloudID is required for google cloud. Please set it to your project ID")
 	}
-	newCluster.ProviderConfig().CloudId = options.CloudID
+
+	providerConfig := newCluster.ProviderConfig()
+	providerConfig.CloudId = options.CloudID
+	newCluster.SetProviderConfig(providerConfig)
 
 	// Expand state store path
 	// Todo (@kris-nova) please pull this into a filepath package or something


### PR DESCRIPTION
This PR fixes cluster creation and provisioning process for Google Cloud Engine.

Changelog:
* [x] Fix Cluster creation process.
* [x] Fix `--cloudId` flag not setting the Google Cloud ID.
* [x] Update Bootstrap Scripts to use Kubernetes 1.9.2 and CNI 0.6.0.
* [x] Use WeaveNet instead of Calico.
* [x] Use `kubeadm` configuration file instead of command-line flags.

```
[marko@xmudrii-1 kubicorn]$ kubectl get nodes
NAME                    STATUS    ROLES     AGE       VERSION
mycluster-master-q13f   Ready     master    2m        v1.9.2
mycluster-node-pppw     Ready     <none>    1m        v1.9.2
mycluster-node-t3bv     Ready     <none>    1m        v1.9.2
```

Sonobuoy tests: All 125 tests are passing.
![Sonobuoy conformance tests](https://user-images.githubusercontent.com/18719127/37863293-5a2a772a-2f5c-11e8-8f0d-23ea1440e4f6.png)
