### PR TITLE
Enable UDP traffic on all ports between k8s master and nodes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,6 +1,7 @@
 Ajit Kumar <kumaraji@google.com>
 Alejandro Escobar <jaescobar.cell@gmail.com>
 Alex Tasioulis <tasioulis.alex@gmail.com>
+Andrés Alvarez <andres.alvarez@tupl.com>
 Ann Hill <ahill@appnexus.com>
 Arpit Mohan <me@arpitmohan.com>
 Avi Deitcher <avi@deitcher.net>

--- a/profiles/digitalocean/centos_7.go
+++ b/profiles/digitalocean/centos_7.go
@@ -70,6 +70,11 @@ func NewCentosCluster(name string) *cluster.Cluster {
 								IngressSource:   fmt.Sprintf("%s-node", name),
 								IngressProtocol: "tcp",
 							},
+							{
+								IngressToPort:   "all",
+								IngressSource:   fmt.Sprintf("%s-node", name),
+								IngressProtocol: "udp",
+							},
 						},
 						EgressRules: []*cluster.EgressRule{
 							{
@@ -110,6 +115,11 @@ func NewCentosCluster(name string) *cluster.Cluster {
 								IngressToPort:   "all",
 								IngressSource:   fmt.Sprintf("%s-master", name),
 								IngressProtocol: "tcp",
+							},
+							{
+								IngressToPort:   "all",
+								IngressSource:   fmt.Sprintf("%s-master", name),
+								IngressProtocol: "udp",
 							},
 						},
 						EgressRules: []*cluster.EgressRule{

--- a/profiles/digitalocean/controller_ubuntu_16_04.go
+++ b/profiles/digitalocean/controller_ubuntu_16_04.go
@@ -76,6 +76,11 @@ func NewControllerUbuntuCluster(name string) *cluster.Cluster {
 								IngressSource:   fmt.Sprintf("%s-node", name),
 								IngressProtocol: "tcp",
 							},
+							{
+								IngressToPort:   "all",
+								IngressSource:   fmt.Sprintf("%s-node", name),
+								IngressProtocol: "udp",
+							},
 						},
 						EgressRules: []*cluster.EgressRule{
 							{
@@ -117,6 +122,11 @@ func NewControllerUbuntuCluster(name string) *cluster.Cluster {
 								IngressToPort:   "all",
 								IngressSource:   fmt.Sprintf("%s-master", name),
 								IngressProtocol: "tcp",
+							},
+							{
+								IngressToPort:   "all",
+								IngressSource:   fmt.Sprintf("%s-master", name),
+								IngressProtocol: "udp",
 							},
 						},
 						EgressRules: []*cluster.EgressRule{

--- a/profiles/digitalocean/ubuntu_16_04.go
+++ b/profiles/digitalocean/ubuntu_16_04.go
@@ -70,6 +70,11 @@ func NewUbuntuCluster(name string) *cluster.Cluster {
 								IngressSource:   fmt.Sprintf("%s-node", name),
 								IngressProtocol: "tcp",
 							},
+							{
+								IngressToPort:   "all",
+								IngressSource:   fmt.Sprintf("%s-node", name),
+								IngressProtocol: "udp",
+							},
 						},
 						EgressRules: []*cluster.EgressRule{
 							{
@@ -110,6 +115,11 @@ func NewUbuntuCluster(name string) *cluster.Cluster {
 								IngressToPort:   "all",
 								IngressSource:   fmt.Sprintf("%s-master", name),
 								IngressProtocol: "tcp",
+							},
+							{
+								IngressToPort:   "all",
+								IngressSource:   fmt.Sprintf("%s-master", name),
+								IngressProtocol: "udp",
 							},
 						},
 						EgressRules: []*cluster.EgressRule{


### PR DESCRIPTION
Current digitalocean based profiles don't take into account UDP internal communication when creating firewall rules. This leads to failures as nodes are not able to contact master on UDP ports (required for instance for DNS)

This Pull Request adds an UDP rule for all ports based on labels (in the same way it's already handled for TCP ports) allowing communication for UDP protocol between masters and nodes.