### PR TITLE
Fix golint build issue (wrong import)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ endif
 
 	GOLINT_CMD=$(shell command -v golint 2> /dev/null)
 ifndef GOLINT_CMD
-	go get github.com/golang/lint/golint
+	go get golang.org/x/lint/golint
 endif
 
 .PHONY: help


### PR DESCRIPTION
This PR fixes the golint import path, which is currently causing travis builds to fail.