### PR TITLE
fix issue with submodule protocol - cloning over SSH instead of HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "bootstrap"]
 	path = bootstrap
-	url = https://github.com:kubicorn/bootstrap.git
+	url = https://github.com/kubicorn/bootstrap.git
+

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "bootstrap"]
 	path = bootstrap
-	url = git@github.com:kubicorn/bootstrap.git
+	url = https://github.com:kubicorn/bootstrap.git


### PR DESCRIPTION
When executing the install command from the docs it's going to fail
because it's trying to also fetch the submodule, and it was doing that
via SSH instead of HTTPS protocol.

As a result, replace the submodule's protocol with HTTPS so that anyone
can freely issue `go get github.com/kubicorn/kubicorn` and have the binary directly compiled in their `${GOPATH}`

Resolves: #686
Related:
Signed-off-by: Daniel Andrei Minca